### PR TITLE
Query Godaddy for the registered domain, not the FQDN

### DIFF
--- a/certbot_dns_godaddy.py
+++ b/certbot_dns_godaddy.py
@@ -11,6 +11,7 @@ from certbot import errors, interfaces
 from certbot.plugins import dns_common, dns_common_lexicon
 from lexicon.providers import godaddy
 from requests.exceptions import RequestException
+import tldextract
 
 logger = logging.getLogger(__name__)
 
@@ -81,8 +82,9 @@ class _GodaddyLexiconClient(dns_common_lexicon.LexiconClient):
         :param str record_content: The record content (typically the challenge validation).
         :raises errors.PluginError: if an error occurs communicating with the DNS Provider API
         """
+        ex = tldextract.extract(domain)
         try:
-            self._find_domain_id(domain)
+            self._find_domain_id(ex.registered_domain)
         except errors.PluginError as e:
             logger.debug('Encountered error finding domain_id during add: %s', e, exc_info=True)
             return
@@ -102,8 +104,9 @@ class _GodaddyLexiconClient(dns_common_lexicon.LexiconClient):
         :param str record_content: The record content (typically the challenge validation).
         :raises errors.PluginError: if an error occurs communicating with the DNS Provider  API
         """
+        ex = tldextract.extract(domain)
         try:
-            self._find_domain_id(domain)
+            self._find_domain_id(ex.registered_domain)
         except errors.PluginError as e:
             logger.debug('Encountered error finding domain_id during deletion: %s', e, exc_info=True)
             return


### PR DESCRIPTION
Currently the FQDN is used in the Godaddy API call. Since GD requires the registered domain, we get a 404 back. This patch strips out the registered domain and uses it in the Godaddy call. Works for me :-)