### PR TITLE
Fix arguments provided to Godaddy lexicon provider

### DIFF
--- a/certbot_dns_godaddy.py
+++ b/certbot_dns_godaddy.py
@@ -90,7 +90,7 @@ class _GodaddyLexiconClient(dns_common_lexicon.LexiconClient):
             return
 
         try:
-            self.provider.create_record(rtype='TXT', name=record_name, content=record_content])
+            self.provider.create_record(rtype='TXT', name=record_name, content=record_content)
         except RequestException as e:
             logger.debug('Encountered error adding TXT record: %s', e, exc_info=True)
             raise errors.PluginError('Error adding TXT record: {0}'.format(e))
@@ -112,6 +112,6 @@ class _GodaddyLexiconClient(dns_common_lexicon.LexiconClient):
             return
 
         try:
-            self.provider.delete_record(rtype='TXT', name=record_name, content=record_content])
+            self.provider.delete_record(rtype='TXT', name=record_name, content=record_content)
         except RequestException as e:
             logger.debug('Encountered error deleting TXT record: %s', e, exc_info=True)

--- a/certbot_dns_godaddy.py
+++ b/certbot_dns_godaddy.py
@@ -90,7 +90,7 @@ class _GodaddyLexiconClient(dns_common_lexicon.LexiconClient):
             return
 
         try:
-            self.provider.create_record(*['TXT', record_name, record_content])
+            self.provider.create_record(rtype='TXT', name=record_name, content=record_content])
         except RequestException as e:
             logger.debug('Encountered error adding TXT record: %s', e, exc_info=True)
             raise errors.PluginError('Error adding TXT record: {0}'.format(e))
@@ -112,6 +112,6 @@ class _GodaddyLexiconClient(dns_common_lexicon.LexiconClient):
             return
 
         try:
-            self.provider.delete_record(*['TXT', record_name, record_content])
+            self.provider.delete_record(rtype='TXT', name=record_name, content=record_content])
         except RequestException as e:
             logger.debug('Encountered error deleting TXT record: %s', e, exc_info=True)


### PR DESCRIPTION
The arguments that the lexicon base provider accepts have changed for the [`update_record`](https://github.com/AnalogJ/lexicon/blob/9475eb01b6beb3ac996ce70a14bc81c0749275c7/lexicon/providers/base.py#L94) and [`delete_record`](https://github.com/AnalogJ/lexicon/blob/9475eb01b6beb3ac996ce70a14bc81c0749275c7/lexicon/providers/base.py#L106) methods. These now take an identifier as the first argument. The proposed changes here fix this issue and provide the required values as keyword arguments to prevent such argument order changes from breaking this plugin.

Fixes #3